### PR TITLE
Fix to allow experiment to start if DefaultConfig folder doesn't exist

### DIFF
--- a/Assets/Scripts/trial/FieldTrial.cs
+++ b/Assets/Scripts/trial/FieldTrial.cs
@@ -23,13 +23,17 @@ namespace trial
             // This block of code will use the default configuration file if
             // using webGL or Android (can add others in if statement) 
             // Otherwise calls the directory picker to select the configuration file.
-
-            var DefaultConfigPath = Application.streamingAssetsPath + "/Default_Config/";
-            var files = Directory.GetFiles(DefaultConfigPath);
+    
+            var defaultConfigDir = Application.streamingAssetsPath + "/Default_Config/";
+            var files = new string[0];
+            if (Directory.Exists(defaultConfigDir))
+            {
+                files = Directory.GetFiles(defaultConfigDir);
+            }
 
             if (files.Length > 0)
             {
-                string defaultConfig = DefaultConfigPath + Path.GetFileName(files[0]);
+                var defaultConfig = defaultConfigDir + Path.GetFileName(files[0]);
                 Loader.ExternalActivation(defaultConfig);
             }
             else

--- a/Assets/StreamingAssets/Default_Config.meta
+++ b/Assets/StreamingAssets/Default_Config.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2c2b538e325ad67448dba412af484270
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue where experiment wont start if DefaultConfig folder doesn't exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Default config doesn't fail silently if the folder doesn't exist.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
