### PR TITLE
Fix - timing square color alternation

### DIFF
--- a/Assets/Scripts/Timing/TimingSquare.cs
+++ b/Assets/Scripts/Timing/TimingSquare.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using main;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace Assets.Scripts.Timing
@@ -19,7 +20,7 @@ namespace Assets.Scripts.Timing
             if (data.DataSingleton.GetData().TimingVerification)
             {
                 timingBox.enabled = true;
-                if (data.DataSingleton.GetData().TrialInitialValue % 2 == 0)
+                if (Loader.Get().CurrTrial.TrialProgress.TrialNumber % 2 == 0)
                 {
                     Debug.Log("Changing square to black");
                     timingBox.color = Color.black;

--- a/Assets/Scripts/data/Data.cs
+++ b/Assets/Scripts/data/Data.cs
@@ -17,9 +17,6 @@ namespace data
         // whether or not to turn on timing diagnostics
         public bool TimingVerification;
 
-        // value from which trials start incrementing in the config file. 
-        public int TrialInitialValue = 1;
-
         // The amount of delay (in seconds) before a trial loads in. This value is used to 
         // ensure a consitent loading time between trials.
         public float TrialLoadingDelay = 3.0f;

--- a/Assets/Scripts/trial/AbstractTrial.cs
+++ b/Assets/Scripts/trial/AbstractTrial.cs
@@ -92,8 +92,6 @@ namespace trial
                 t.NumCollectedPerBlock = new int[NumBlocks];
             }
 
-            Debug.Log("Current Trial Increment: " + data.DataSingleton.GetData().TrialInitialValue);
-
             if (t.TrialNumber < 2)
             {
                 t.TimeSinceExperimentStart = 0.0f;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `TrialInitialValue` is no longer used, and was removed.
- Timing square color is now based on `TrialNumber`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Require for timing testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by @kbnealy 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
